### PR TITLE
Contribución para consumir webservice SIC para consultas de cédulas jurídicas, físicas y DIMEX

### DIFF
--- a/api/contrib/sicWsQuery/README.md
+++ b/api/contrib/sicWsQuery/README.md
@@ -1,0 +1,13 @@
+# Modulo para hacer consultas de cédulas de personas físicas o juridicas al WebService en Hacienda (SIC)
+Se enviar                               
+        origen Inidica que tipo de cédula se va a consultar (Fisico,  Juridico o DIMEX)
+        cedula Número de cédula que se desea consultar (Los números deben enviarse junto con el digito verificador de pertenencia)
+		ape1 Primer apellido de la persona física (En caso de que la consulta sea de cedula de persona física)
+		ape2 Segundo apellido de la persona física (En caso de que la consulta sea de cedula de persona física)
+		nomb1 Primer nombre de la persona física (En caso de que la consulta sea de cedula de persona física)
+		nomb2 Segundo nombre de la persona física (En caso de que la consulta sea de cedula de persona física)
+		razon Nombre de la razón social en caso de que la consulta sea por persona jurídica
+
+Nota
+        A manera de ejemplo, esta consulta funciona como una sentencia WHERE con condiciones OR, es decir
+        se hace un filtro tomando en cuenta todos los parametros que tienen algún valor

--- a/api/contrib/sicWsQuery/module.php
+++ b/api/contrib/sicWsQuery/module.php
@@ -1,0 +1,84 @@
+<?php
+/** @file module.php
+ * A brief file description.
+ * A more elaborated file description.
+ */
+
+/** \addtogroup Core 
+ *  @{
+ */
+
+/**
+ * \defgroup Module
+ * @{
+ */
+
+
+/**
+ * Boot up procedure
+ */
+function ejemplo_bootMeUp(){
+	// Just booting up
+}
+
+/**
+ * Init function
+ */
+
+
+function sicWsQuery_init(){
+
+	$paths = array(
+		array(
+			'r' => 'sicWsQuery',
+			'action' => 'sicWsQuery',
+			'access' => 'users_openAccess', 
+			'access_params' => 'accessName',
+			'params' => array(
+				array("key" => "origen", "def" => "", "req" => true),
+				array("key" => "cedula", "def" => "", "req" => true),
+				array("key" => "ape1", "def" => "", "req" => true),
+				array("key" => "ape2", "def" => "", "req" => true),
+				array("key" => "nomb1", "def" => "", "req" => true),
+				array("key" => "nomb2", "def" => "", "req" => true),
+				array("key" => "razon", "def" => "", "req" => true),
+				array("key" => "Concatenado", "def" => "", "req" => true)
+			),	
+			'file' => 'sicWsQuery.php'
+		)
+	);
+
+	return $paths;
+}
+
+
+/**************************************************/
+//In the access you can use users_openAccess if you want anyone can use the function
+// or users_loggedIn if the user must be logged in
+/**************************************************/
+
+
+
+/**
+ * Get the perms for this module
+ */
+function MODULENAME_access(){
+
+	$perms = array(
+		array(
+			# A human readable name
+			'name'        => 'Do something with this module',
+			# Something to remember what it is for
+			'description' => 'What can be achieved with this permission',
+			# Internal machine name, no spaces, no funny symbols, same rules as a variable
+			# Use yourmodule_ prefix
+			'code'        => 'mymodule_access_one',
+			# Default value in case it is not set
+			'def'        => false, //Or true, you decide
+		),
+	);
+
+}
+
+/**@}*/
+/** @}*/

--- a/api/contrib/sicWsQuery/sicWsQuery.php
+++ b/api/contrib/sicWsQuery/sicWsQuery.php
@@ -1,0 +1,45 @@
+<?php
+
+ini_set('soap.wsdl_cache_enabled', 0);
+ini_set('soap.wsdl_cache_ttl', 900);
+ini_set('default_socket_timeout', 15);
+
+// TODO: Implementar la función que genere el digito verificador de pertenencia para poder hacer la consulta al webservice.
+//       Adaptarlo al ejemplo de la API
+$options = [
+    'uri'                => 'http://schemas.xmlsoap.org/soap/envelope/',
+    'style'              => SOAP_RPC,
+    'use'                => SOAP_ENCODED,
+    'soap_version'       => SOAP_1_1,
+    'cache_wsdl'         => WSDL_CACHE_NONE,
+    'connection_timeout' => 15,
+    'trace'              => true,
+    'encoding'           => 'UTF-8',
+    'exceptions'         => true,
+];
+
+// El webservice en Hacienda hace la consulta utilizando los valores
+// de parámetro que no estén vacíos, así que se puede hacer una consulta
+// haciendo combinaciones.
+$params = [
+    'origen'      => params_get('origen'), // Fisico,  Juridico o DIMEX
+    'cedula'      => params_get('cedula'),
+    'ape1'        => params_get('ape1'),
+    'ape2'        => params_get('ape2'),
+    'nomb1'       => params_get('nomb1'),
+    'nomb2'       => params_get('nomb2'),
+    'razon'       => params_get('razon'),
+    'Concatenado' => params_get('Concatenado')
+];
+
+$wsdl = "http://196.40.56.20/wsInformativasSICWEB/Service1.asmx?WSDL";
+
+try {
+    $soap = new SoapClient($wsdl, $options);
+    $data = $soap->ObtenerDatos($params);
+}
+catch(Exception $e) {
+    die($e->getMessage());
+}
+    
+var_dump($data->ObtenerDatosResult);


### PR DESCRIPTION
Quedan algunos TODOS:

- Implementar la función que calcule el digito verificador de pertencia
- Implementar consultar localmente si el webservice no funciona (tal y como lo hace la aplicación de escritorio)
- Implemetar un mecanismo que pueda descarhar el msi, descomprimirlo y actualizar el registro local basado en al mdb que dispone Hacienda en este instalador