### PR TITLE
Agregar link al 'step by step' del API al README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ La que se llama www contiene un archivo de configuración, en donde se modifican
 * Instalación php-xml
 * Openssl
 
+### Información acerca de la instalación y uso del API
+
+Encuentra toda la información unificada en el documento [Step by Step del API](https://crlibre.org/wp-content/uploads/2018/07/Documento-API-Instalacion-CRLibre.docx)
+
 ### Necesitas más información? [Visita el Wiki del API](https://github.com/CRLibre/API_Hacienda/wiki "Wiki CRLibre API_Hacienda")
 
 ----------------------------------------------


### PR DESCRIPTION
Al día de hoy la página de Instalación y requerimientos técnicos del API se encuentra vacía, mientras se construye sería beneficioso agregar un link directo al documento Step by Step, cuyo link solo he encontrado la pagina de crlibre.org, de esta forma podemos ir manteniendo todo lo related al proyecto aquí mismo en el repo.