### PR TITLE
ajuste en generacion de XML, nodo CorreoElectronico es opcional

### DIFF
--- a/api/contrib/genXML/genXML.php
+++ b/api/contrib/genXML/genXML.php
@@ -181,9 +181,10 @@ function genXMLFe()
                     </Fax>';
         }
 
-        $xmlString .= '
-            <CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>
-        </Receptor>';
+        if ($receptorEmail != '' )
+            $xmlString .= '<CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>';
+
+        $xmlString .= '</Receptor>';
     }
 
     $xmlString .= '
@@ -458,9 +459,10 @@ function genXMLNC()
                     </Fax>';
         }
 
-        $xmlString .= '
-            <CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>
-        </Receptor>';
+        if ($receptorEmail != '' )
+            $xmlString .= '<CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>';
+
+        $xmlString .= '</Receptor>';
     }
 
     $xmlString .= '
@@ -738,10 +740,10 @@ function genXMLND()
                     </Fax>';
         }
 
-        $xmlString .= '
-            <CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>
-        </Receptor>';
-    }
+        if ($receptorEmail != '' )
+            $xmlString .= '<CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>';
+
+        $xmlString .= '</Receptor>';
 
     $xmlString .= '
     <CondicionVenta>' . $condVenta . '</CondicionVenta>

--- a/api/contrib/genXML/genXML.php
+++ b/api/contrib/genXML/genXML.php
@@ -181,7 +181,7 @@ function genXMLFe()
                     </Fax>';
         }
 
-        if ($receptorEmail != '' )
+        if ($receptorEmail != '')
             $xmlString .= '<CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>';
 
         $xmlString .= '</Receptor>';
@@ -459,7 +459,7 @@ function genXMLNC()
                     </Fax>';
         }
 
-        if ($receptorEmail != '' )
+        if ($receptorEmail != '')
             $xmlString .= '<CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>';
 
         $xmlString .= '</Receptor>';
@@ -740,7 +740,7 @@ function genXMLND()
                     </Fax>';
         }
 
-        if ($receptorEmail != '' )
+        if ($receptorEmail != '')
             $xmlString .= '<CorreoElectronico>' . $receptorEmail . '</CorreoElectronico>';
 
         $xmlString .= '</Receptor>';


### PR DESCRIPTION
El **CorreoElectronico** del receptor es opcional, se modifican las funciones de creacion de XML para que no se incluya este campo si el API no lo recibe en sus parámetros.
<img width="494" alt="screen shot 2018-11-11 at 9 15 18 am" src="https://user-images.githubusercontent.com/1874087/48314677-69ee2200-e592-11e8-803e-2d50b20a1714.png">
