### PR TITLE
ajuste en generacion de XML, nodo Barrio es opcional

### DIFF
--- a/api/contrib/genXML/genXML.php
+++ b/api/contrib/genXML/genXML.php
@@ -99,11 +99,14 @@ function genXMLFe()
     if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorOtrasSenas != '')
     {
         $xmlString .= '
-            <Ubicacion>
-                <Provincia>' . $emisorProv . '</Provincia>
-                <Canton>' . $emisorCanton . '</Canton>
-                <Distrito>' . $emisorDistrito . '</Distrito>
-                <Barrio>' . $emisorBarrio . '</Barrio>
+        <Ubicacion>
+            <Provincia>' . $emisorProv . '</Provincia>
+            <Canton>' . $emisorCanton . '</Canton>
+            <Distrito>' . $emisorDistrito . '</Distrito>';
+        if ($emisorBarrio != '')
+            $xmlString .= '
+                <Barrio>' . $emisorBarrio . '</Barrio>';
+        $xmlString .= '
                 <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
             </Ubicacion>';
     }

--- a/api/contrib/genXML/genXML.php
+++ b/api/contrib/genXML/genXML.php
@@ -953,7 +953,7 @@ function genXMLTE()
         </Identificacion>
         <NombreComercial>' . $nombreComercial . '</NombreComercial>';
 
-    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorBarrio != '' && $emisorOtrasSenas != '')
+    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorOtrasSenas != '')
     {
         $xmlString .= '
         <Ubicacion>

--- a/api/contrib/genXML/genXML.php
+++ b/api/contrib/genXML/genXML.php
@@ -96,7 +96,7 @@ function genXMLFe()
             </Identificacion>
             <NombreComercial>' . $nombreComercial . '</NombreComercial>';
 
-    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorBarrio != '' && $emisorOtrasSenas != '')
+    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorOtrasSenas != '')
     {
         $xmlString .= '
             <Ubicacion>
@@ -153,14 +153,18 @@ function genXMLFe()
                 </Identificacion>';
             }
 
-            if ($receptorProvincia != '' && $receptorCanton != '' && $receptorDistrito != '' && $receptorBarrio != '' && $receptorOtrasSenas != '')
+            if ($receptorProvincia != '' && $receptorCanton != '' && $receptorDistrito != '' && $receptorOtrasSenas != '')
             {
-                $xmlString .= '<Ubicacion>
-                             <Provincia>' . $receptorProvincia . '</Provincia>
-                            <Canton>' . $receptorCanton . '</Canton>
-                            <Distrito>' . $receptorDistrito . '</Distrito>
-                            <Barrio>' . $receptorBarrio . '</Barrio>
-                            <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
+                $xmlString .= '
+                    <Ubicacion>
+                        <Provincia>' . $receptorProvincia . '</Provincia>
+                        <Canton>' . $receptorCanton . '</Canton>
+                        <Distrito>' . $receptorDistrito . '</Distrito>';
+                if ($receptorBarrio != '')
+                    $xmlString .= '
+                        <Barrio>' . $receptorBarrio . '</Barrio>';
+                $xmlString .= '
+                        <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
                     </Ubicacion>';
             }
         }
@@ -373,16 +377,19 @@ function genXMLNC()
         <NombreComercial>' . $nombreComercial . '</NombreComercial>';
 
 
-    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorBarrio != '' && $emisorOtrasSenas != '')
+    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorOtrasSenas != '')
     {
         $xmlString .= '
         <Ubicacion>
             <Provincia>' . $emisorProv . '</Provincia>
             <Canton>' . $emisorCanton . '</Canton>
-            <Distrito>' . $emisorDistrito . '</Distrito>
-            <Barrio>' . $emisorBarrio . '</Barrio>
-            <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
-        </Ubicacion>';
+            <Distrito>' . $emisorDistrito . '</Distrito>';
+        if ($emisorBarrio != '')
+            $xmlString .= '
+                <Barrio>' . $emisorBarrio . '</Barrio>';
+        $xmlString .= '
+                <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
+            </Ubicacion>';
     }
 
     if ($emisorCodPaisTel != '' && $emisorTel != '')
@@ -431,14 +438,18 @@ function genXMLNC()
                 </Identificacion>';
             }
 
-            if ($receptorProvincia != '' && $receptorCanton != '' && $receptorDistrito != '' && $receptorBarrio != '' && $receptorOtrasSenas != '')
+            if ($receptorProvincia != '' && $receptorCanton != '' && $receptorDistrito != '' && $receptorOtrasSenas != '')
             {
-                $xmlString .= '<Ubicacion>
-                             <Provincia>' . $receptorProvincia . '</Provincia>
-                            <Canton>' . $receptorCanton . '</Canton>
-                            <Distrito>' . $receptorDistrito . '</Distrito>
-                            <Barrio>' . $receptorBarrio . '</Barrio>
-                            <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
+                $xmlString .= '
+                    <Ubicacion>
+                        <Provincia>' . $receptorProvincia . '</Provincia>
+                        <Canton>' . $receptorCanton . '</Canton>
+                        <Distrito>' . $receptorDistrito . '</Distrito>';
+                if ($receptorBarrio != '')
+                    $xmlString .= '
+                        <Barrio>' . $receptorBarrio . '</Barrio>';
+                $xmlString .= '
+                        <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
                     </Ubicacion>';
             }
         }
@@ -655,16 +666,19 @@ function genXMLND()
         </Identificacion>
         <NombreComercial>' . $nombreComercial . '</NombreComercial>';
 
-    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorBarrio != '' && $emisorOtrasSenas != '')
+    if ($emisorProv != '' && $emisorCanton != '' && $emisorDistrito != '' && $emisorOtrasSenas != '')
     {
         $xmlString .= '
         <Ubicacion>
             <Provincia>' . $emisorProv . '</Provincia>
             <Canton>' . $emisorCanton . '</Canton>
-            <Distrito>' . $emisorDistrito . '</Distrito>
-            <Barrio>' . $emisorBarrio . '</Barrio>
-            <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
-        </Ubicacion>';
+            <Distrito>' . $emisorDistrito . '</Distrito>';
+        if ($emisorBarrio != '')
+            $xmlString .= '
+                <Barrio>' . $emisorBarrio . '</Barrio>';
+        $xmlString .= '
+                <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
+            </Ubicacion>';
     }
 
     if ($emisorCodPaisTel != '' && $emisorTel != '')
@@ -712,14 +726,18 @@ function genXMLND()
                 </Identificacion>';
             }
 
-            if ($receptorProvincia != '' && $receptorCanton != '' && $receptorDistrito != '' && $receptorBarrio != '' && $receptorOtrasSenas != '')
+            if ($receptorProvincia != '' && $receptorCanton != '' && $receptorDistrito != '' && $receptorOtrasSenas != '')
             {
-                $xmlString .= '<Ubicacion>
-                             <Provincia>' . $receptorProvincia . '</Provincia>
-                            <Canton>' . $receptorCanton . '</Canton>
-                            <Distrito>' . $receptorDistrito . '</Distrito>
-                            <Barrio>' . $receptorBarrio . '</Barrio>
-                            <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
+                $xmlString .= '
+                    <Ubicacion>
+                        <Provincia>' . $receptorProvincia . '</Provincia>
+                        <Canton>' . $receptorCanton . '</Canton>
+                        <Distrito>' . $receptorDistrito . '</Distrito>';
+                if ($receptorBarrio != '')
+                    $xmlString .= '
+                        <Barrio>' . $receptorBarrio . '</Barrio>';
+                $xmlString .= '
+                        <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
                     </Ubicacion>';
             }
         }
@@ -941,10 +959,13 @@ function genXMLTE()
         <Ubicacion>
             <Provincia>' . $emisorProv . '</Provincia>
             <Canton>' . $emisorCanton . '</Canton>
-            <Distrito>' . $emisorDistrito . '</Distrito>
-            <Barrio>' . $emisorBarrio . '</Barrio>
-            <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
-        </Ubicacion>';
+            <Distrito>' . $emisorDistrito . '</Distrito>';
+        if ($emisorBarrio != '')
+            $xmlString .= '
+                <Barrio>' . $emisorBarrio . '</Barrio>';
+        $xmlString .= '
+                <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
+            </Ubicacion>';
     }
 
     if ($emisorCodPaisTel != '' && $emisorTel != '')

--- a/api/contrib/genXML/genXML.php
+++ b/api/contrib/genXML/genXML.php
@@ -104,8 +104,7 @@ function genXMLFe()
             <Canton>' . $emisorCanton . '</Canton>
             <Distrito>' . $emisorDistrito . '</Distrito>';
         if ($emisorBarrio != '')
-            $xmlString .= '
-                <Barrio>' . $emisorBarrio . '</Barrio>';
+            $xmlString .= '<Barrio>' . $emisorBarrio . '</Barrio>';
         $xmlString .= '
                 <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
             </Ubicacion>';
@@ -164,8 +163,7 @@ function genXMLFe()
                         <Canton>' . $receptorCanton . '</Canton>
                         <Distrito>' . $receptorDistrito . '</Distrito>';
                 if ($receptorBarrio != '')
-                    $xmlString .= '
-                        <Barrio>' . $receptorBarrio . '</Barrio>';
+                    $xmlString .= '<Barrio>' . $receptorBarrio . '</Barrio>';
                 $xmlString .= '
                         <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
                     </Ubicacion>';
@@ -388,8 +386,7 @@ function genXMLNC()
             <Canton>' . $emisorCanton . '</Canton>
             <Distrito>' . $emisorDistrito . '</Distrito>';
         if ($emisorBarrio != '')
-            $xmlString .= '
-                <Barrio>' . $emisorBarrio . '</Barrio>';
+            $xmlString .= '<Barrio>' . $emisorBarrio . '</Barrio>';
         $xmlString .= '
                 <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
             </Ubicacion>';
@@ -449,8 +446,7 @@ function genXMLNC()
                         <Canton>' . $receptorCanton . '</Canton>
                         <Distrito>' . $receptorDistrito . '</Distrito>';
                 if ($receptorBarrio != '')
-                    $xmlString .= '
-                        <Barrio>' . $receptorBarrio . '</Barrio>';
+                    $xmlString .= '<Barrio>' . $receptorBarrio . '</Barrio>';
                 $xmlString .= '
                         <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
                     </Ubicacion>';
@@ -677,8 +673,7 @@ function genXMLND()
             <Canton>' . $emisorCanton . '</Canton>
             <Distrito>' . $emisorDistrito . '</Distrito>';
         if ($emisorBarrio != '')
-            $xmlString .= '
-                <Barrio>' . $emisorBarrio . '</Barrio>';
+            $xmlString .= '<Barrio>' . $emisorBarrio . '</Barrio>';
         $xmlString .= '
                 <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
             </Ubicacion>';
@@ -737,8 +732,7 @@ function genXMLND()
                         <Canton>' . $receptorCanton . '</Canton>
                         <Distrito>' . $receptorDistrito . '</Distrito>';
                 if ($receptorBarrio != '')
-                    $xmlString .= '
-                        <Barrio>' . $receptorBarrio . '</Barrio>';
+                    $xmlString .= '<Barrio>' . $receptorBarrio . '</Barrio>';
                 $xmlString .= '
                         <OtrasSenas>' . $receptorOtrasSenas . '</OtrasSenas>
                     </Ubicacion>';
@@ -964,8 +958,7 @@ function genXMLTE()
             <Canton>' . $emisorCanton . '</Canton>
             <Distrito>' . $emisorDistrito . '</Distrito>';
         if ($emisorBarrio != '')
-            $xmlString .= '
-                <Barrio>' . $emisorBarrio . '</Barrio>';
+            $xmlString .= '<Barrio>' . $emisorBarrio . '</Barrio>';
         $xmlString .= '
                 <OtrasSenas>' . $emisorOtrasSenas . '</OtrasSenas>
             </Ubicacion>';


### PR DESCRIPTION
El **Barrio** del emisor y receptor es opcional, se modifican las funciones de creacion de XML para que no se incluya este campo si el API no lo recibe en sus parámetros.
<img width="580" alt="Barrio es opcional en Emisor" src="https://user-images.githubusercontent.com/1874087/48979430-4d68e400-f080-11e8-86d3-211be2be05f2.png">
<img width="580" alt="Barrio es opcional en Receptor" src="https://user-images.githubusercontent.com/1874087/48979433-535ec500-f080-11e8-96e5-09099e0efc9e.png">
