### PR TITLE
Warning: implode(): Invalid arguments passed in /var/www/api/core/gra…

### DIFF
--- a/api/core/grace.php
+++ b/api/core/grace.php
@@ -34,6 +34,7 @@ define('GRACE_PRINT_ERROR', conf_get('print_error', 'debug'));
  *  @{
  */
 //! Debug messages stored in Grace
+$ grace_logMsgs = array();
 global $grace_logMsgs;
 
 /** @} */


### PR DESCRIPTION
…ce.php on line 85

La función de implosión en php requiere que $ grace_logMsgs sea una array.