### PR TITLE
Correcion de sintaxis del array

### DIFF
--- a/api/core/grace.php
+++ b/api/core/grace.php
@@ -34,7 +34,7 @@ define('GRACE_PRINT_ERROR', conf_get('print_error', 'debug'));
  *  @{
  */
 //! Debug messages stored in Grace
-$ grace_logMsgs = array();
+$grace_logMsgs = array();
 global $grace_logMsgs;
 
 /** @} */


### PR DESCRIPTION
Eliminado del espacio entre el $ y nombre del arreglo en grace.php:
`$ grace_logMsgs = array();`  a `$grace_logMsgs = array();`
