### PR TITLE
Update docker-php-apache/Dockerfile

### DIFF
--- a/docker-php-apache/Dockerfile
+++ b/docker-php-apache/Dockerfile
@@ -10,8 +10,10 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 COPY ./www/ /var/www/html
 COPY ./api/ /var/www/api
 RUN mkdir -p /var/www/api/errors
+RUN mkdir -p /var/www/api/logs
 RUN chmod -R 755 /var/www/
 RUN chmod -R 777 /var/www/api/errors
+RUN chmod -R 777 /var/www/api/logs
 RUN ln -s /usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]


### PR DESCRIPTION
Saludos 😄 

Solicito este cambio debido a que la carpeta `/var/www/api/logs` no se está incluyendo para crearla en el Dockerfile.  

Por lo que he leído en el fichero `api/modules/cala/settings.php` línea **95** *(master branch)* busca este directorio si se desea hacer un debug, sin embargo, en la Issue #94 se reporta inconvenientes para iniciar la API, por lo que analizando lo mencionado en ella he dado con este cambio una solución.

